### PR TITLE
Permission to use the "geraintluff" JSFX effects

### DIFF
--- a/3RD-PARTY-LICENSES
+++ b/3RD-PARTY-LICENSES
@@ -93,9 +93,9 @@ https://github.com/michaelwillis/dragonfly-reverb/blob/master/LICENSE
 for all the FX under the "src/common/dsp/geraint_luff" folder:
 --------------------------------------------------------
 
-Copyright (C) 20xx Geraint Luff
+Copyright (C) 2016 and later Geraint Luff
 
-TODO: Which license?
+Used in MixMaxtrix with permission from the author.
 
 for all the FX under the "src/common/dsp/liteon" folder:
 --------------------------------------------------------


### PR DESCRIPTION
I don't have a license, but you can use it in MixMaxtrix. 🙂